### PR TITLE
Move the call to get_world to an uncalled function

### DIFF
--- a/hello_lib/src/lib.rs
+++ b/hello_lib/src/lib.rs
@@ -1,7 +1,10 @@
 pub fn get_hello_world() -> String {
-    format!("Hello {}", world_lib::get_world())
+    "Hello world!".into()
 }
 
+pub fn get_hello_world_with_dependency() -> String {
+    format!("Hello {}", world_lib::get_world())
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Reorganize things so that a dependent of the hello_lib crate will not have an actual dependency on the world_lib crate if it does not have a call path that reaches get_hello_world_with_dependency.