### PR TITLE
Move the call to get_world to an uncalled function

### DIFF
--- a/hello_lib/src/lib.rs
+++ b/hello_lib/src/lib.rs
@@ -1,7 +1,10 @@
 pub fn get_hello_world() -> String {
-    format!("Hello {}", world_lib::get_world())
+    "Hello world!".into()
 }
 
+pub fn get_hello_world_with_dependency() -> String {
+    format!("Hello {}", world_lib::get_world())
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Provide an additional entry point, get_hello_world_with_dependency, and move the call to get_world to it. This way, the dependency, world_lib, becomes a transitive dependency only of callers to get_hello_world_with_dependency.